### PR TITLE
docs(readme): qualified cask name for Homebrew 6.0 tap-trust gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ MacCrab is an on-device security engine that monitors your Mac in real time usin
 ```bash
 # 1. Install
 brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab
-brew install --cask maccrab
+brew install --cask peterhanily/maccrab/maccrab
 
 # 2. Open the dashboard
 open /Applications/MacCrab.app
@@ -47,6 +47,14 @@ open /Applications/MacCrab.app
 #    extension in System Settings → General → Login Items & Extensions →
 #    Endpoint Security Extensions.
 ```
+
+> **Homebrew 6.0+:** the fully-qualified cask name (`peterhanily/maccrab/maccrab`) is required — it tells Homebrew to trust this one cask. The bare `--cask maccrab` now fails with `Refusing to load cask … from untrusted tap`.
+
+> **Updating from an older install?** If `brew install`/`brew update` errors with `could not apply …` (a rebase/cherry-pick conflict), your cached tap clone is stale — reset it, then re-run the install:
+>
+> ```bash
+> brew untap peterhanily/maccrab && brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab
+> ```
 
 > **Note:** Full Endpoint Security coverage requires granting Full Disk Access to MacCrab.app in **System Settings > Privacy & Security > Full Disk Access**.
 


### PR DESCRIPTION
## Why

Homebrew **6.0.0** (released 2026-06-11) made third-party **tap trust** a default hard requirement. The documented install command now fails for everyone on 6.0+:

```
Error: Refusing to load cask peterhanily/maccrab/maccrab from untrusted tap peterhanily/maccrab.
```

Trust is stored **per-user/local** — there is **no maintainer-side** way to publish a tap as pre-trusted (verified against the official Homebrew 6.0 blog, the Tap-Trust doc, the 6.0.0 release notes, and the maintain-a-tap doc). So the install instructions are the only place to fix it. A **fully-qualified** install (`brew install --cask peterhanily/maccrab/maccrab`) trusts that one cask with no separate `brew trust` step — Homebrew's own recommended pattern.

## What

- README install command: `--cask maccrab` → `--cask peterhanily/maccrab/maccrab`. (The explicit tap URL stays — this repo is the non-conventional `peterhanily/maccrab`, not `homebrew-maccrab`, so Homebrew can't auto-resolve it.)
- Added a returning-user note: a stale tap clone (this repo's history was force-pushed at one point) makes `brew update` fail with a rebase/cherry-pick "could not apply" error; fix is untap + re-tap.

## Companion

The website (`peterhanily/maccrab-site`) had the same broken command in three live spots including the Copy button — fixed and **already deployed to maccrab.com** (commit `09ed05c`).

Doc-only change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)