### PR TITLE
docs(trust): qualified cask name in TRUST.md install command

### DIFF
--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -20,7 +20,7 @@ page to start from.
 | Sparkle appcast feed | `https://maccrab.com/appcast.xml` |
 | Sparkle EdDSA public key | First 8 chars: `de+dzPjB`. Full key in `Xcode/Resources/MacCrabApp-Info.plist` under `SUPublicEDKey`. |
 | GitHub release page | `https://github.com/peterhanily/maccrab/releases` |
-| Homebrew tap | `peterhanily/maccrab` — install with `brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab && brew install --cask maccrab` |
+| Homebrew tap | `peterhanily/maccrab` — install with `brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab && brew install --cask peterhanily/maccrab/maccrab` |
 | Security contact | `maccrab@peterhanily.com` (see `SECURITY.md`) |
 
 ## Verifying a downloaded DMG


### PR DESCRIPTION
Follow-up to #4. The last forward-facing **bare** `brew install --cask maccrab` in the docs lived in `docs/TRUST.md` — it fails on Homebrew 6.0's tap-trust gate just like the README + site did. Switched to the fully-qualified `peterhanily/maccrab/maccrab`, which auto-trusts that one cask.

No other forward-facing bare *install* commands remain: the `brew upgrade`/`uninstall`/`reinstall` references across CHANGELOG, RELEASE_NOTES, UPGRADE, FAQ operate on an *already-trusted* installed cask, where the short name works. Historical per-release notes and the CI-regenerated, Sparkle-load-bearing `appcast.xml` are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)