### PR TITLE
feat(tap): dedicated homebrew-maccrab tap + one-line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ MacCrab is an on-device security engine that monitors your Mac in real time usin
 
 ```bash
 # 1. Install
-brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab
 brew install --cask peterhanily/maccrab/maccrab
 
 # 2. Open the dashboard
@@ -48,12 +47,13 @@ open /Applications/MacCrab.app
 #    Endpoint Security Extensions.
 ```
 
-> **Homebrew 6.0+:** the fully-qualified cask name (`peterhanily/maccrab/maccrab`) is required — it tells Homebrew to trust this one cask. The bare `--cask maccrab` now fails with `Refusing to load cask … from untrusted tap`.
+> **Homebrew 6.0+:** the fully-qualified cask name (`peterhanily/maccrab/maccrab`) auto-taps the official [`homebrew-maccrab`](https://github.com/peterhanily/homebrew-maccrab) tap and trusts this cask in one step. The bare `--cask maccrab` fails with `Refusing to load cask … from untrusted tap`.
 
-> **Updating from an older install?** If `brew install`/`brew update` errors with `could not apply …` (a rebase/cherry-pick conflict), your cached tap clone is stale — reset it, then re-run the install:
+> **Tapped the app repo before?** If you previously ran `brew tap … https://github.com/peterhanily/maccrab` and now hit a `could not apply …` rebase error on update — or `brew install` reports `Cask 'maccrab' is unreadable` / `syntax errors found` — your cached tap clone is stale. Switch to the clean tap, then re-run the install:
 >
 > ```bash
-> brew untap peterhanily/maccrab && brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab
+> brew untap peterhanily/maccrab
+> brew install --cask peterhanily/maccrab/maccrab
 > ```
 
 > **Note:** Full Endpoint Security coverage requires granting Full Disk Access to MacCrab.app in **System Settings > Privacy & Security > Full Disk Access**.

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -20,7 +20,7 @@ page to start from.
 | Sparkle appcast feed | `https://maccrab.com/appcast.xml` |
 | Sparkle EdDSA public key | First 8 chars: `de+dzPjB`. Full key in `Xcode/Resources/MacCrabApp-Info.plist` under `SUPublicEDKey`. |
 | GitHub release page | `https://github.com/peterhanily/maccrab/releases` |
-| Homebrew tap | `peterhanily/maccrab` — install with `brew tap peterhanily/maccrab https://github.com/peterhanily/maccrab && brew install --cask peterhanily/maccrab/maccrab` |
+| Homebrew tap | `peterhanily/homebrew-maccrab` — install with `brew install --cask peterhanily/maccrab/maccrab` |
 | Security contact | `maccrab@peterhanily.com` (see `SECURITY.md`) |
 
 ## Verifying a downloaded DMG

--- a/scripts/publish-cask.sh
+++ b/scripts/publish-cask.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# publish-cask.sh — Publish the locally-bumped Casks/maccrab.rb into the
+# dedicated peterhanily/homebrew-maccrab tap repo via the GitHub Contents API.
+#
+# Why a separate tap repo + the Contents API:
+#   The app repo (peterhanily/maccrab) used to double as the Homebrew tap.
+#   When its main-branch history was force-pushed/rewritten, every existing
+#   tap clone could no longer fast-forward — `brew update` fell back to a
+#   rebase, failed, and left merge-conflict markers in maccrab.rb (unparseable
+#   cask → install impossible). The Contents API creates exactly ONE
+#   forward-only commit per call (never a force-push / rebase), so the tap is
+#   always fast-forwardable. Mirrors publish-release-json.sh.
+#
+# Usage:
+#   export TAP_REPO_TOKEN=...   # PAT with contents:write on homebrew-maccrab
+#                               # (falls back to GH_TOKEN, then SITE_REPO_TOKEN)
+#   scripts/publish-cask.sh
+#
+# Reads ./Casks/maccrab.rb and PUTs it to
+# peterhanily/homebrew-maccrab/Casks/maccrab.rb on main.
+
+set -euo pipefail
+
+CASK_PATH="${CASK_PATH:-Casks/maccrab.rb}"
+TAP_REPO="${TAP_REPO:-peterhanily/homebrew-maccrab}"
+DEST_PATH="${DEST_PATH:-Casks/maccrab.rb}"
+BRANCH="${BRANCH:-main}"
+# Prefer a dedicated token; fall back to the broad-scope gh OAuth token, then
+# the site PAT. Whichever is used needs contents:write on $TAP_REPO.
+TOKEN="${TAP_REPO_TOKEN:-${GH_TOKEN:-${SITE_REPO_TOKEN:-}}}"
+
+[[ -n "$TOKEN" ]] || {
+    echo "ERROR: no token — set TAP_REPO_TOKEN (or GH_TOKEN / SITE_REPO_TOKEN) with write access to $TAP_REPO" >&2
+    exit 2
+}
+[[ -f "$CASK_PATH" ]] || {
+    echo "ERROR: $CASK_PATH not found — run from the repo root after the cask is bumped" >&2
+    exit 1
+}
+
+# Never propagate the exact breakage this whole setup exists to prevent: refuse
+# to publish a cask carrying unresolved merge-conflict markers.
+if grep -qE '^(<<<<<<<|=======|>>>>>>>)' "$CASK_PATH"; then
+    echo "ERROR: $CASK_PATH contains merge-conflict markers — refusing to publish" >&2
+    exit 1
+fi
+
+VERSION=$(grep -E '^[[:space:]]*version[[:space:]]+"' "$CASK_PATH" \
+          | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^"]*' | head -1 || true)
+[[ -n "$VERSION" ]] || {
+    echo "ERROR: couldn't parse version from $CASK_PATH" >&2
+    exit 1
+}
+
+echo "Publishing $CASK_PATH to ${TAP_REPO}/${DEST_PATH} on $BRANCH (v$VERSION)..."
+
+API="https://api.github.com/repos/${TAP_REPO}/contents/${DEST_PATH}"
+
+# Current blob SHA (PUT requires it to update an existing file).
+CURRENT=$(curl -sS -H "Authorization: Bearer $TOKEN" "${API}?ref=${BRANCH}" \
+          | python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha",""))' 2>/dev/null || echo "")
+
+B64=$(base64 -i "$CASK_PATH")
+
+PAYLOAD=$(python3 -c "
+import json
+sha = '$CURRENT'
+payload = {
+    'message': 'maccrab: bump cask to v$VERSION',
+    'content': '''$B64'''.replace('\n', ''),
+    'branch': '$BRANCH',
+}
+if sha:
+    payload['sha'] = sha
+print(json.dumps(payload))
+")
+
+RESPONSE=$(curl -sS -X PUT \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -d "$PAYLOAD" \
+    "$API")
+
+COMMIT=$(echo "$RESPONSE" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("commit", {}).get("html_url", ""))' 2>/dev/null || echo "")
+
+if [[ -n "$COMMIT" ]]; then
+    echo "✓ Published cask: $COMMIT"
+    echo "  brew install --cask peterhanily/maccrab/maccrab now serves v$VERSION"
+else
+    echo "ERROR: cask publish failed. Response:" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -297,6 +297,23 @@ elif [ -n "${SITE_REPO_TOKEN:-}" ] && [ -f "$DMG_PATH" ]; then
     if [ "$cross_check_ok" = "1" ]; then
         echo "  ✓ release.json, Casks/maccrab.rb, and GitHub release all agree on SHA ${local_release_sha:0:16}..."
     fi
+
+    # Step 6d: Publish the validated cask to the dedicated, append-only tap
+    # repo (peterhanily/homebrew-maccrab) via the GitHub Contents API. New
+    # users install with the one-liner
+    #   brew install --cask peterhanily/maccrab/maccrab
+    # which auto-taps that repo. Contents-API publishing is forward-only (one
+    # clean commit, never a force-push), so `brew update` always fast-forwards
+    # — unlike the old app-repo-as-tap, whose rewritten history poisoned every
+    # existing clone with rebase conflicts. Token needs write on the tap repo.
+    echo ""
+    echo "Step 6d: Publishing cask to homebrew-maccrab tap..."
+    if TAP_REPO_TOKEN="${TAP_REPO_TOKEN:-${GH_TOKEN:-$SITE_REPO_TOKEN}}" \
+            "$SCRIPT_DIR/publish-cask.sh"; then
+        echo "  ✓ Cask published; 'brew install --cask peterhanily/maccrab/maccrab' serves v$VERSION"
+    else
+        echo "  ! Cask publish failed — set TAP_REPO_TOKEN (PAT with contents:write on peterhanily/homebrew-maccrab) then run 'scripts/publish-cask.sh' manually" >&2
+    fi
 else
     echo ""
     echo "  Step 6/6: Skipping appcast publish."
@@ -317,5 +334,5 @@ echo ""
 echo "  DMG: .build/MacCrab-v$VERSION.dmg"
 echo ""
 echo "  Users can install with:"
-echo "    brew install --cask https://raw.githubusercontent.com/peterhanily/maccrab/main/Casks/maccrab.rb"
+echo "    brew install --cask peterhanily/maccrab/maccrab"
 echo ""


### PR DESCRIPTION
Stands up a dedicated, append-only Homebrew tap (**[peterhanily/homebrew-maccrab](https://github.com/peterhanily/homebrew-maccrab)** — already created + seeded) so MacCrab installs with one command and stops breaking users' `brew update`.

## Root cause this fixes
The app repo doubled as the tap, and its `main` history was force-pushed once (`3f67ebb` → `032ee59`). A force-push makes every existing tap clone un-fast-forwardable — `brew update` falls back to a rebase, fails, and leaves git conflict markers inside `Casks/maccrab.rb`, so the cask becomes unparseable (`Cask 'maccrab' is unreadable / syntax errors found`). A dedicated tap published **append-only via the GitHub Contents API** (one forward-only commit per release, never force-pushed) is always fast-forwardable.

## Changes
- **`scripts/publish-cask.sh`** (new) — PUTs `Casks/maccrab.rb` to the tap via the Contents API (mirrors `publish-release-json.sh`); refuses to publish a cask with conflict markers; fail-loud on a missing commit URL.
- **`scripts/release.sh`** — Step 6d publishes the validated cask to the tap (after the 6c SHA cross-check), soft-failing so a publish hiccup never aborts the release; final install hint → one-liner.
- **`README.md` + `docs/TRUST.md`** — install is now `brew install --cask peterhanily/maccrab/maccrab` (auto-taps the conventional repo + grants Homebrew 6.0 tap-trust in one step). Migration note for returning users (untap → reinstall) names BOTH the `could not apply` rebase error and the `unreadable / syntax errors` symptom.

Companion: the **site** one-liner is already deployed (maccrab-site `9c9b338`).

Adversarial review: **SHIP-WITH-FIXES** — the one-liner auto-tap + append-only publish verified TRUE; both flagged P1 doc facets folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)