### PR TITLE
fix(cask): use non-deprecated depends_on macos: :ventura

### DIFF
--- a/Casks/maccrab.rb
+++ b/Casks/maccrab.rb
@@ -7,7 +7,7 @@ cask "maccrab" do
   desc "Local-first macOS threat detection engine with Sigma-compatible rules"
   homepage "https://github.com/peterhanily/maccrab"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "MacCrab.app"
   binary "bin/maccrabctl"

--- a/homebrew/maccrab.rb
+++ b/homebrew/maccrab.rb
@@ -7,7 +7,7 @@ cask "maccrab" do
   desc "Local-first macOS threat detection engine with Sigma-compatible rules"
   homepage "https://github.com/peterhanily/maccrab"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "MacCrab.app"
   binary "bin/maccrabctl"


### PR DESCRIPTION
Homebrew deprecated the string-comparison form `depends_on macos: ">= :ventura"` — it prints a warning on every install/upgrade and "will be removed in a later release." The bare symbol `depends_on macos: :ventura` is the modern equivalent with **identical** semantics ("Ventura or newer", verified against the [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)), so this silences the warning without changing the supported-macOS floor — Sonoma/Sequoia/Tahoe users still install.

Applied to both `Casks/maccrab.rb` and the legacy `homebrew/maccrab.rb`. The live tap (`peterhanily/homebrew-maccrab`) was already updated via `scripts/publish-cask.sh` (commit `7f3ce32`), which also live-validated the append-only publish path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)